### PR TITLE
update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ America 2019][kubecon-talk].
 To use this within Terraform, add a `module` block like:
 
 ```hcl
-# TODO: not sure if this is correct, will doublecheck after first release to https://www.terraform.io/docs/registry/modules/publish.html
-module "kubeflow_cluster" {
-  source = "spotify/gke-kubeflow-cluster"
+module "kubeflow-cluster" {
+  source  = "spotify/kubeflow-cluster/gke"
+  version = "0.0.1"
 }
 ```
+
+For more details, see https://registry.terraform.io/modules/spotify/kubeflow-cluster/gke/0.0.1
 
 ## Module details
 


### PR DESCRIPTION
now that I've been able to publish a first release to the official Terraform registry, I can update the install instructions in the README (earlier I had just a guess at the correct block in the doc).